### PR TITLE
object reference count 버그 수정

### DIFF
--- a/JobDispatcher/JobDispatcher.h
+++ b/JobDispatcher/JobDispatcher.h
@@ -198,7 +198,7 @@ void DoAsync(T instance, F memfunc, Args&&... args)
 	static_assert(true == is_shared_ptr<T>::value, "T should be shared_ptr");
 	static_assert(true == std::is_convertible<T, std::shared_ptr<AsyncExecutable>>::value, "T should be shared_ptr AsyncExecutable");
 	
-	JobEntry* job = new JobEntry(std::bind(memfunc, instance, std::forward<Args>(args)...));
+	JobEntry* job = new JobEntry(std::bind(memfunc, instance.get(), std::forward<Args>(args)...));
 
 	std::static_pointer_cast<AsyncExecutable>(instance)->DoTask(job);
 } 
@@ -209,6 +209,6 @@ void DoAsyncAfter(uint32_t after, T instance, F memfunc, Args&&... args)
 	static_assert(true == is_shared_ptr<T>::value, "T should be shared_ptr");
 	static_assert(true == std::is_convertible<T, std::shared_ptr<AsyncExecutable>>::value, "T should be shared_ptr AsyncExecutable");
 
-	JobEntry* job = new JobEntry(std::bind(memfunc, instance, std::forward<Args>(args)...));
+	JobEntry* job = new JobEntry(std::bind(memfunc, instance.get(), std::forward<Args>(args)...));
 	LTimer->PushTimerJob(std::static_pointer_cast<AsyncExecutable>(instance), after, job);
 }

--- a/JobDispatcher/Timer.cpp
+++ b/JobDispatcher/Timer.cpp
@@ -35,7 +35,12 @@ void Timer::DoTimerJob()
 		if (LTickCount < timerJobElem.mExecutionTick )
 			break ;
 
-		timerJobElem.mOwner->DoTask(timerJobElem.mTask); ///< pass to the dispatcher
+		auto owner = timerJobElem.mOwner.lock();
+
+		if (owner != nullptr)
+		{
+			owner->DoTask(timerJobElem.mTask); ///< pass to the dispatcher
+		}
 	
 		mTimerJobQueue.pop();
 	}

--- a/JobDispatcher/Timer.h
+++ b/JobDispatcher/Timer.h
@@ -9,7 +9,7 @@
 
 
 class AsyncExecutable;
-typedef std::shared_ptr<AsyncExecutable> AsyncExecutablePtr;
+typedef std::weak_ptr<AsyncExecutable> AsyncExecutablePtr;
 
 struct TimerJobElement
 {


### PR DESCRIPTION
교수님께서 말씀하신 버그가 이게 맞는지 솔직히 확신은 못하겠지만 그나마 제 생각에 버그인 것 같아보이는 부분 하나 찾아서 고쳐보았습니다 ㅋㅋ

test 코드에서 주석처리 되어있던 DoAsyncAfter 부분을 주석 해제하고 돌린 후 마지막에 각 TestObject들의 reference count를 확인해보니 reference count가 1이 나와야하는데 훨씬 높은 값이 나오는 걸 확인했습니다. 이게 Timer가 모든 DoAsyncAfter 작업을 끝내기 전에 스레드가 종료되면서 파괴되면 bind할 때 값 전달 때문에 증가한 std::shared_ptr 값이 제대로 감소하지 못해 발생하는 문제인 듯 하여 이 부분만 고쳐보았습니다.

timer가 bind할 때 해당 자원을 shared_ptr로 가져가면서 생기는 문제라고 생각해서 bind할 때는 raw pointer로 넘기고, 다만 이렇게 하면 댕글링 문제가 발생할 수 있으니 timer가 내부적으로 저장하는 owner 값을 weak_ptr로 바꾸고 lock 함수를 통해 확인해서 살아 있으면 task를 수행하는 방식으로 바꾸는 걸로 해결했습니다. 이렇게 하니 reference count 문제는 해결되네요. 
